### PR TITLE
Modularize YAML and JSON loading and add YAML::XS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,13 @@ matrix:
     - perl: "5.18"
       env: WITH_JSON_XS=1 WITH_YAML_SYCK=1
     - perl: "5.18"
+      env: WITH_JSON_XS=1 WITH_YAML_XS=1
+    - perl: "5.18"
       env: WITH_JSON=1 WITH_YAML=1
     - perl: "5.18"
       env: WITH_YAML_SYCK=1
+    - perl: "5.18"
+      env: WITH_YAML_XS=1
     - perl: "5.18"
       env: WITH_YAML=1
     - perl: "5.18"
@@ -26,6 +30,7 @@ before_install:
   - '[ "$WITH_JSON_XS"   =  1 ] && cpanm --quiet --notest JSON::XS                           || true'
   - '[ "$WITH_JSON"      =  1 ] && cpanm --quiet --notest JSON                               || true'
   - '[ "$WITH_YAML_SYCK" =  1 ] && cpanm --quiet --notest YAML::Syck                         || true'
+  - '[ "$WITH_YAML_XS"   =  1 ] && cpanm --quiet --notest YAML::XS                           || true'
   - '[ "$WITH_YAML"      =  1 ] && cpanm --quiet --notest YAML                               || true'
   - '[ "$WITH_IPC_RUN"   =  1 ] && cpanm --quiet --notest IPC::Run                           || true'
 after_script:

--- a/pkwalify
+++ b/pkwalify
@@ -20,9 +20,11 @@ use Kwalify;
 use Getopt::Long;
 
 my $schema_file;
+my $parse_mod;
 my $silent;
 my $show_version;
 GetOptions("f=s"       => \$schema_file,
+	   "m|module=s" => \$parse_mod,
 	   "s|silent"  => \$silent,
 	   "v|version" => \$show_version,
 	   "h|help"    => sub { print usage(); exit 0 },
@@ -73,7 +75,9 @@ sub read_file {
     my $file = shift;
 
     my @try_order;
-    if ($file =~ m{\.json$}i) {
+    if (defined $parse_mod) {
+	@try_order = ($parse_mod);
+    } elsif ($file =~ m{\.json$}i) {
 	@try_order = ('JSON::XS', 'JSON', 'YAML::Syck', 'YAML');
     } else { # yaml or don't know
 	@try_order = ('YAML::Syck', 'YAML', 'JSON::XS', 'JSON');
@@ -104,6 +108,8 @@ sub read_file {
 	    };
 	    return ($data) if $data && !$@;
 	    push @errors, $@;
+	} else {
+	    push @errors, "Unsupported module $try";
 	}
     }
     if (!@errors) {
@@ -131,7 +137,7 @@ sub usage {
 	$msg = "";
     }
     <<EOF;
-${msg}usage: $0 [-v] [-s] -f schema.yml data.yml
+${msg}usage: $0 [-v] [-s] [-m parse-mod] -f schema.yml data.yml
        $0 -f schema.json data.json
 EOF
 }
@@ -154,7 +160,7 @@ pkwalify - Kwalify schema for data structures
 
 =head1 SYNOPSIS
 
-    pkwalify [-v] [-s] -f schemafile datafile
+    pkwalify [-v] [-s] [-m parse-mod] -f schemafile datafile
 
 =head1 DESCRIPTION
 
@@ -164,6 +170,7 @@ L<YAML> or L<JSON> file) against a schema defined with I<schemafile>
 
 It is required that either L<YAML> or L<YAML::Syck> is installed to
 parse YAML files, or either L<JSON> or L<JSON::XS> for JSON files.
+Or the module specified on the command-line.
 
 The program returns the number of errors found in the datafile. An
 exit status 0 means no errors.
@@ -175,6 +182,11 @@ exit status 0 means no errors.
 =item -f I<schemafile>
 
 Specify a schema file, either as YAML or JSON. Required.
+
+=item -m I<parse-mod>
+
+Specify the YAML or JSON Perl module to use. Valid modules are:
+L<YAML>, L<YAML::Syck>, L<JSON> and L<JSON::XS>.
 
 =item -s
 

--- a/pkwalify
+++ b/pkwalify
@@ -78,15 +78,19 @@ sub read_file {
     if (defined $parse_mod) {
 	@try_order = ($parse_mod);
     } elsif ($file =~ m{\.json$}i) {
-	@try_order = ('JSON::XS', 'JSON', 'YAML::Syck', 'YAML');
+	@try_order = ('JSON::XS', 'JSON', 'YAML::Syck', 'YAML', 'YAML::XS');
     } else { # yaml or don't know
-	@try_order = ('YAML::Syck', 'YAML', 'JSON::XS', 'JSON');
+	@try_order = ('YAML::Syck', 'YAML', 'YAML::XS', 'JSON::XS', 'JSON');
     }
 
     my @errors;
     for my $try (@try_order) {
 	if      ($try eq 'YAML::Syck' && eval { require YAML::Syck; 1 }) {
 	    my @data = eval { YAML::Syck::LoadFile($file) };
+	    return @data if !$@;
+	    push @errors, $@;
+	} elsif ($try eq 'YAML::XS'   && eval { require YAML::XS; 1 }) {
+	    my @data = eval { YAML::XS::LoadFile($file) };
 	    return @data if !$@;
 	    push @errors, $@;
 	} elsif ($try eq 'YAML'       && eval { require YAML; 1 }) {
@@ -168,9 +172,9 @@ B<pkwalify> validates the data from I<datafile> (which may be a
 L<YAML> or L<JSON> file) against a schema defined with I<schemafile>
 (which also may be a YAML or JSON file).
 
-It is required that either L<YAML> or L<YAML::Syck> is installed to
-parse YAML files, or either L<JSON> or L<JSON::XS> for JSON files.
-Or the module specified on the command-line.
+It is required that either L<YAML>, L<YAML::XS> or L<YAML::Syck> is
+installed to parse YAML files, or either L<JSON> or L<JSON::XS> for
+JSON files. Or the module specified on the command-line.
 
 The program returns the number of errors found in the datafile. An
 exit status 0 means no errors.
@@ -186,7 +190,7 @@ Specify a schema file, either as YAML or JSON. Required.
 =item -m I<parse-mod>
 
 Specify the YAML or JSON Perl module to use. Valid modules are:
-L<YAML>, L<YAML::Syck>, L<JSON> and L<JSON::XS>.
+L<YAML>, L<YAML::XS>, L<YAML::Syck>, L<JSON> and L<JSON::XS>.
 
 =item -s
 
@@ -208,7 +212,8 @@ Slaven Reziæ, E<lt>srezic@cpan.orgE<gt>
 
 =head1 SEE ALSO
 
-L<Kwalify>, L<kwalify(1)>, L<JSON>, L<JSON::XS>, L<YAML>, L<YAML::Syck>.
+L<Kwalify>, L<kwalify(1)>, L<JSON>, L<JSON::XS>, L<YAML>, L<YAML::XS>,
+L<YAML::Syck>.
 
 =cut
 


### PR DESCRIPTION
This merge adds a new -m option to pkwalify so that one can explicitly request which parser module to use. And also adds support for YAML::XS.

This should fix #3.